### PR TITLE
Unbound systemd overrides affect Service section, not the Unit

### DIFF
--- a/Docker-Compose.yml
+++ b/Docker-Compose.yml
@@ -218,7 +218,7 @@ storage:
     - path: /etc/systemd/system/unbound.service.d/override.conf
       contents:
         inline: |
-          [Unit]
+          [Service]
           MemoryDenyWriteExecute=true
           PrivateDevices=true
           PrivateTmp=true

--- a/Generic.yml
+++ b/Generic.yml
@@ -216,7 +216,7 @@ storage:
     - path: /etc/systemd/system/unbound.service.d/override.conf
       contents:
         inline: |
-          [Unit]
+          [Service]
           MemoryDenyWriteExecute=true
           PrivateDevices=true
           PrivateTmp=true


### PR DESCRIPTION
Noticed following entries in unbound journald log:

```
Apr 11 19:02:51 localhost systemd[1]: /etc/systemd/system/unbound.service.d/override.conf:2: Unknown key name 'MemoryDenyWriteExecute' in section 'Unit', ignoring.
Apr 11 19:02:51 localhost systemd[1]: /etc/systemd/system/unbound.service.d/override.conf:3: Unknown key name 'PrivateDevices' in section 'Unit', ignoring.
Apr 11 19:02:51 localhost systemd[1]: /etc/systemd/system/unbound.service.d/override.conf:4: Unknown key name 'PrivateTmp' in section 'Unit', ignoring.
Apr 11 19:02:51 localhost systemd[1]: /etc/systemd/system/unbound.service.d/override.conf:5: Unknown key name 'ProtectHome' in section 'Unit', ignoring.
Apr 11 19:02:51 localhost systemd[1]: /etc/systemd/system/unbound.service.d/override.conf:6: Unknown key name 'ProtectClock' in section 'Unit', ignoring.
Apr 11 19:02:51 localhost systemd[1]: /etc/systemd/system/unbound.service.d/override.conf:7: Unknown key name 'ProtectControlGroups' in section 'Unit', ignoring.
Apr 11 19:02:51 localhost systemd[1]: /etc/systemd/system/unbound.service.d/override.conf:8: Unknown key name 'ProtectKernelLogs' in section 'Unit', ignoring.
Apr 11 19:02:51 localhost systemd[1]: /etc/systemd/system/unbound.service.d/override.conf:9: Unknown key name 'ProtectKernelModules' in section 'Unit', ignoring.
Apr 11 19:02:51 localhost systemd[1]: /etc/systemd/system/unbound.service.d/override.conf:11: Unknown key name 'ProtectKernelTunables' in section 'Unit', ignoring.
Apr 11 19:02:51 localhost systemd[1]: /etc/systemd/system/unbound.service.d/override.conf:12: Unknown key name 'ProtectProc' in section 'Unit', ignoring.
```

then discovered that unbound systemd overrides in butane config files was being applied under the `[Unit]` section instead of the `[Service]` section.

You might have to regenerate the ignition configs since butane seems to be doing funny stuff with base64 coding there.

Also, I hope you don't mind PRs like these? 